### PR TITLE
修改触发器触发次数重置条件

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -7,6 +7,7 @@ use crate::{
 
 /// 事件
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Event {
     LoadTriggers { trigger_mgr: TriggerManager },
     UpdateContext { ctx: Context },

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -62,7 +62,7 @@ pub async fn event_listener(tx: Sender<Event>) {
         tx_send_or_break!(tx.send(Event::UpdateContext { ctx: ctx.clone() }));
 
         if ctx.quest_state != last_ctx.quest_state {
-            debug!("on {}", "Event::QuestStateChanged");
+            debug!("on {} from {:?} to {:?}", "Event::QuestStateChanged", last_ctx.quest_state, ctx.quest_state);
             tx_send_or_break!(tx.send(Event::QuestStateChanged {
                 new: ctx.quest_state,
                 old: last_ctx.quest_state,

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -324,12 +324,16 @@ impl TriggerManager {
 
     pub fn dispatch(&mut self, event: &Event) {
         // 需要广播的消息
-        match event.event_type() {
-            EventType::QuestStateChanged => {
-                self.broadcast_and_reset(event);
+        match event {
+            Event::QuestStateChanged { new, .. } => {
+                if new == &1 {
+                    self.broadcast_and_reset(event);
+                } else {
+                    self.broadcast(event);
+                }
                 return;
-            },
-            EventType::Damage => {
+            }
+            Event::Damage { .. } => {
                 self.broadcast(event);
                 return;
             }


### PR DESCRIPTION
从`QuestStateChanged` 变成当`new state == 1`时才重置计数器为`1`，消除不必要的重置同时提供更准确的计数。
加入`#[allow(dead_code)]`让IDE不要爆黄（强迫症）