### PR TITLE
提升计数器性能以及修正功能

### DIFF
--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -233,12 +233,11 @@ pub struct SendChatMessageEvent {
 
 impl SendChatMessageEvent {
     pub fn new(msg: &str, enabled_cnt: bool) -> Self {
-        let ret = SendChatMessageEvent { 
+        SendChatMessageEvent { 
             msg: msg.to_string(),
             cnt: AtomicI32::new(1),
             enabled_cnt
-        };
-        ret
+        }
     }
 }
 

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -228,16 +228,17 @@ impl AsTrigger for Trigger {
 pub struct SendChatMessageEvent {
     msg: String,
     cnt: AtomicI32,
+    enabled_cnt: bool
 }
 
 impl SendChatMessageEvent {
     pub fn new(msg: &str, enabled_cnt: bool) -> Self {
-        SendChatMessageEvent { 
+        let ret = SendChatMessageEvent { 
             msg: msg.to_string(),
-            cnt: AtomicI32::new({
-                if enabled_cnt { -1 } else { 1 }
-            })
-        }
+            cnt: AtomicI32::new(1),
+            enabled_cnt
+        };
+        ret
     }
 }
 
@@ -250,14 +251,15 @@ impl AsAction for SendChatMessageEvent {
                 msg = msg.replace(&placeholder, value);
             }
         };
-        let cnt = self.cnt.load(atomic::Ordering::Relaxed);
-        if cnt >= 1 {
+        if self.enabled_cnt {
             msg = msg.replace("%d", &self.cnt.fetch_add(1, atomic::Ordering::SeqCst).to_string());
         }
         CHAT_MESSAGE_SENDER.send(&msg);
     }
     fn reset(&self) {
-        self.cnt.store(1, atomic::Ordering::SeqCst);
+        if self.enabled_cnt {
+            self.cnt.store(1, atomic::Ordering::SeqCst);
+        }
     }
 }
 
@@ -372,7 +374,7 @@ pub fn register_trigger(t_cfg: &configs::Trigger, shared_ctx: SharedContext) -> 
         .iter()
         .map(|check_cond| register_check_condition(check_cond, shared_ctx.clone()))
         .for_each(|c| builder.add_check_condition(c));
-
+    
     t_cfg.action.iter().filter_map(|item| match t_cfg.enable_cnt {
         Some(true) => register_action(item, true),
         _ => register_action(item, false)


### PR DESCRIPTION
增加enabled_cnt给SendChatMessageEvent，从而每次发送消息和重置计数器的时候不需要使用atomic load。更新后只需要store。