### PR TITLE
增加触发器关联功能

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -378,11 +378,4 @@ mod tests {
         let longsword = WeaponType::LongSword;
         assert!(ValueCmp::EqInt(3) == longsword.as_i32());
     }
-
-    // #[test]
-    // fn test_convert_to_json() {
-    //     let cfg = load_config(EXAMPLE_FILE_PATH).unwrap();
-    //     let json_cfg = serde_json::to_string(&cfg).unwrap();
-    //     eprintln!("{}", json_cfg);
-    // }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -208,7 +208,7 @@ pub fn parse_config(cfg: &configs::FilteredConfig, shared_ctx: SharedContext) ->
                     })
                 })
             }).collect::<HashMap<_, _>>();
-            named_trigger_registrations.get_mut(root_name).unwrap().trigger_fns.builder.set_linked_triggers(Some(linked_triggers_map));
+            named_trigger_registrations.get_mut(root_name).unwrap().get_trigger_fns_mut().get_builder_mut().set_linked_triggers(Some(linked_triggers_map));
         }
     });
 

--- a/src/triggers.rs
+++ b/src/triggers.rs
@@ -102,6 +102,7 @@ impl TriggerFns {
         }
     }
 
+    #[inline]
     pub fn get_trigger(&self, name: String) -> Option<Arc<TriggerInfo>> {
         if let Some(triggers) = &self.builder.linked_triggers {
             if let Some(trigger) = triggers.get(&name) {
@@ -113,8 +114,20 @@ impl TriggerFns {
         None
     }
 
+    #[inline]
     pub fn get_action(&self, idx: usize) -> Arc<Box<dyn AsAction>> {
         self.builder.actions.get(idx).unwrap().clone()
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub fn get_builder(&self) -> &TriggerBuilder {
+        &self.builder
+    }
+
+    #[inline]
+    pub fn get_builder_mut(&mut self) -> &mut TriggerBuilder {
+        &mut self.builder
     }
 }
 
@@ -226,6 +239,20 @@ pub struct Trigger {
     pub name: Option<String>,
     pub trigger_fns: TriggerFns,
     pub event_type: EventType,
+}
+
+impl Trigger {
+
+    #[inline]
+    #[allow(dead_code)]
+    pub fn get_trigger_fns(&self) -> &TriggerFns {
+        &self.trigger_fns
+    }
+
+    #[inline]
+    pub fn get_trigger_fns_mut(&mut self) -> &mut TriggerFns {
+        &mut self.trigger_fns
+    }
 }
 
 impl std::fmt::Debug for Trigger {


### PR DESCRIPTION
例子
```toml
[[trigger]]
action_mode = "sequential_all"
enable_cnt = true
name = "BackStep Trigger"
link = ["Guard Slash Trigger"]

    [trigger.trigger_on.fsm]
    new = { target = 3, id = 90 }

    [[trigger.check]]
    weapon_type.value = 1

    [[trigger.action]]
    cmd = "SendChatMessage"
    param = "<STYL MOJI_RED_DEFAULT><SIZE 20>后撤步/防御斩 %d/{{ Guard Slash Trigger }}</SIZE></STYL>"

[[trigger]]
action_mode = "sequential_all"
name = "Guard Slash Trigger"
enable_cnt = true

    [trigger.trigger_on.fsm]
    new = { target = 3, id = 79 }

    [[trigger.check]]
    weapon_type.value = 1

    [[trigger.action]]
    cmd = "SendChatMessage"
    param = "<STYL MOJI_YELLOW_DEFAULT><SIZE 20>防御斩 %d</SIZE></STYL>"

```
目前{{ Guard Slash Trigger }}用来替换`SendChatMessageEvent`的cnt值，但是可以自定义一些`文本规则`，因为目前已经可以访问和修改关联的触发器的内存